### PR TITLE
Convert to PCL

### DIFF
--- a/src/ByteSize.Tests/ByteSize.Tests.csproj
+++ b/src/ByteSize.Tests/ByteSize.Tests.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ByteSize\ByteSize.csproj">
-      <Project>{6603f9a8-af5e-4236-9519-0033281cc4af}</Project>
+      <Project>{5044c7a8-4ec1-4eb5-97d4-8b641303f166}</Project>
       <Name>ByteSize</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/ByteSize.sln
+++ b/src/ByteSize.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ByteSize", "ByteSize\ByteSize.csproj", "{6603F9A8-AF5E-4236-9519-0033281CC4AF}"
-EndProject
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30110.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BF53BB43-EB17-4F09-945B-50720C20C77E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ByteSize.Tests", "ByteSize.Tests\ByteSize.Tests.csproj", "{C50AC1B6-1FBD-4BFB-86A7-4D3760AC4E22}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ByteSize", "ByteSize\ByteSize.csproj", "{5044C7A8-4EC1-4EB5-97D4-8B641303F166}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +15,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6603F9A8-AF5E-4236-9519-0033281CC4AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6603F9A8-AF5E-4236-9519-0033281CC4AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6603F9A8-AF5E-4236-9519-0033281CC4AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6603F9A8-AF5E-4236-9519-0033281CC4AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C50AC1B6-1FBD-4BFB-86A7-4D3760AC4E22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C50AC1B6-1FBD-4BFB-86A7-4D3760AC4E22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C50AC1B6-1FBD-4BFB-86A7-4D3760AC4E22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C50AC1B6-1FBD-4BFB-86A7-4D3760AC4E22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5044C7A8-4EC1-4EB5-97D4-8B641303F166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5044C7A8-4EC1-4EB5-97D4-8B641303F166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5044C7A8-4EC1-4EB5-97D4-8B641303F166}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5044C7A8-4EC1-4EB5-97D4-8B641303F166}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ByteSize/ByteSize.cs
+++ b/src/ByteSize/ByteSize.cs
@@ -309,17 +309,25 @@ namespace ByteSize
 
             // Setup the result
             result = new ByteSize();
-            
+
             // Get the index of the first non-digit character
             s = s.TrimStart(); // Protect against leading spaces
-            var num = s
-                .Select((val, index) => new {val, index}) // Get current char & index
-                .FirstOrDefault(x => !(char.IsDigit(x.val) || x.val == '.')); // Pick the first non-digit char
 
-            if (num == null)
+            var num = 0;
+            var found = false;
+
+            // Pick first non-digit number
+            for (num = 0; num < s.Length; num++)
+                if (!(char.IsDigit(s[num]) || s[num] == '.'))
+                {
+                    found = true;
+                    break;
+                }
+
+            if (found == false)
                 return false;
-            
-            int lastNumber = num.index;
+
+            int lastNumber = num;
 
             // Cut the input string in half
             string numberPart = s.Substring(0, lastNumber).Trim();

--- a/src/ByteSize/ByteSize.csproj
+++ b/src/ByteSize/ByteSize.csproj
@@ -1,16 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6603F9A8-AF5E-4236-9519-0033281CC4AF}</ProjectGuid>
+    <ProjectGuid>{5044C7A8-4EC1-4EB5-97D4-8B641303F166}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ByteSize</RootNamespace>
     <AssemblyName>ByteSize</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,19 +33,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ByteSize.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ByteSize/Properties/AssemblyInfo.cs
+++ b/src/ByteSize/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,17 +11,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ByteSize")]
-[assembly: AssemblyCopyright("Copyright © Omar Khudeira 2013")]
+[assembly: AssemblyCopyright("Copyright © Omar Khudeira 2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("39cbce87-7fdb-4adb-a8cc-56c0bdf33b75")]
+[assembly: NeutralResourcesLanguage("en")]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
Converts library to a Portable Class Library with support for .Net 4+, Silverlight 5, WP8, and Windows Store 8+.

Required a small change in the parsing code. All tests passing!
