### PR TITLE
Adding localisation to ToString method

### DIFF
--- a/src/ByteSizeLib.Tests/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/ToStringMethod.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace ByteSizeLib.Tests
@@ -172,6 +174,37 @@ namespace ByteSizeLib.Tests
 
             // Assert
             Assert.Equal("-512 KB", result);
+        }
+
+        [Fact]
+        public void ReturnsLargestMetricSuffixUsingCurrentCulture()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("fr-FR");
+
+            // Arrange
+            var b = ByteSize.FromKiloBytes(10000);
+
+            // Act
+            var result = b.ToString();
+
+            // Assert
+            Assert.Equal("9,77 MB", result);
+
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+
+        [Fact]
+        public void ReturnsLargestMetricSuffixUsingSpecifiedCulture()
+        {
+            // Arrange
+            var b = ByteSize.FromKiloBytes(10000);
+
+            // Act
+            var result = b.ToString("#.#", CultureInfo.CreateSpecificCulture("fr-FR"));
+
+            // Assert
+            Assert.Equal("9,8 MB", result);
         }
     }
 }

--- a/src/ByteSizeLib/ByteSizeLib.cs
+++ b/src/ByteSizeLib/ByteSizeLib.cs
@@ -145,16 +145,23 @@ namespace ByteSizeLib
         /// </summary>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0} {1}", this.LargestWholeNumberValue, this.LargestWholeNumberSymbol);
+            return this.ToString("#.##", CultureInfo.CurrentCulture);
         }
 
         public string ToString(string format)
         {
+            return this.ToString(format, CultureInfo.CurrentCulture);
+        }
+
+        public string ToString(string format, IFormatProvider provider)
+        {
             if (!format.Contains("#") && !format.Contains("0"))
                 format = "#.## " + format;
 
+            if (provider == null) provider = CultureInfo.CurrentCulture;
+
             Func<string, bool> has = s => format.IndexOf(s, StringComparison.CurrentCultureIgnoreCase) != -1;
-            Func<double, string> output = n => n.ToString(format, CultureInfo.InvariantCulture);
+            Func<double, string> output = n => n.ToString(format, provider);
 
             if (has("PB"))
                 return output(this.PetaBytes);
@@ -167,14 +174,14 @@ namespace ByteSizeLib
             if (has("KB"))
                 return output(this.KiloBytes);
 
-            // Byte and Bit symbol look must be case-sensitive
+            // Byte and Bit symbol must be case-sensitive
             if (format.IndexOf(ByteSize.ByteSymbol) != -1)
                 return output(this.Bytes);
 
             if (format.IndexOf(ByteSize.BitSymbol) != -1)
                 return output(this.Bits);
 
-            return string.Format("{0} {1}", this.LargestWholeNumberValue.ToString(format, CultureInfo.InvariantCulture), this.LargestWholeNumberSymbol);
+            return string.Format("{0} {1}", this.LargestWholeNumberValue.ToString(format, provider), this.LargestWholeNumberSymbol);
         }
 
         public override bool Equals(object value)


### PR DESCRIPTION
This change allows ByteSize number formatting to localise correctly. This should resolve Issue #8

We're using ByteSize in a system that supports more than one culture. We think all of the Cultures use the standard suffix (KB, MB etc) so nothing needed doing here. However other cultures use different decimal separators for example French uses a comma. The main change is to work from CurrentCulture instead of InvariantCulture.

Now as a single commit.