### PR TITLE
Reduce struct size from 56 bytes to the recommended 16

### DIFF
--- a/src/ByteSizeLib/ByteSize.cs
+++ b/src/ByteSizeLib/ByteSize.cs
@@ -28,11 +28,11 @@ namespace ByteSizeLib
 
         public long Bits { get; private set; }
         public double Bytes { get; private set; }
-        public double KiloBytes { get; private set; }
-        public double MegaBytes { get; private set; }
-        public double GigaBytes { get; private set; }
-        public double TeraBytes { get; private set; }
-        public double PetaBytes { get; private set; }
+        public double KiloBytes => Bytes / BytesInKiloByte;
+        public double MegaBytes => Bytes / BytesInMegaByte;
+        public double GigaBytes => Bytes / BytesInGigaByte;
+        public double TeraBytes => Bytes / BytesInTeraByte;
+        public double PetaBytes => Bytes / BytesInPetaByte;
 
         public string LargestWholeNumberSymbol
         {
@@ -95,11 +95,6 @@ namespace ByteSizeLib
             Bits = (long)Math.Ceiling(byteSize * BitsInByte);
 
             Bytes = byteSize;
-            KiloBytes = byteSize / BytesInKiloByte;
-            MegaBytes = byteSize / BytesInMegaByte;
-            GigaBytes = byteSize / BytesInGigaByte;
-            TeraBytes = byteSize / BytesInTeraByte;
-            PetaBytes = byteSize / BytesInPetaByte;
         }
 
         public static ByteSize FromBits(long value)


### PR DESCRIPTION
`ByteSize` weighs in at 56 bytes, which is far from the recommendation of 16 bytes for value types (to avoid excessive copying and bloating other value types). This PR turns `KiloBytes`, `GigaBytes`, `TeraBytes` and `PetaBytes` into pure computed properties because these are trivial calculations and not all of them may be needed by the user. This brings the size of `ByteSize` to 16 bytes and also avoids the cost of computing them during initialization if they're never used.