### PR TITLE
$default-branch syntax is not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: DotNet
 on:
   pull_request:
     branches:
-      - $default-branch
+      - master
   push:
     branches:
-      - $default-branch
+      - master
   release:
     types: [published]
 


### PR DESCRIPTION
Oh $default-branch is meant for github workflow templates.... That makes no sense...

https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/sharing-workflows-with-your-organization#creating-a-workflow-template