### PR TITLE
General code cleanup (without any semantic changes)

### DIFF
--- a/src/ByteSizeLib.Tests/Binary/CreatingMethods.cs
+++ b/src/ByteSizeLib.Tests/Binary/CreatingMethods.cs
@@ -1,6 +1,6 @@
 ﻿using Xunit;
 
-namespace ByteSizeLib.Tests.BinaryByteSizeTests
+namespace ByteSizeLib.Tests.Binary
 {
     public class CreatingMethods
     {

--- a/src/ByteSizeLib.Tests/Binary/ParsingMethods.cs
+++ b/src/ByteSizeLib.Tests/Binary/ParsingMethods.cs
@@ -1,6 +1,6 @@
 ﻿using Xunit;
 
-namespace ByteSizeLib.Tests.BinaryByteSizeTests
+namespace ByteSizeLib.Tests.Binary
 {
     public class ParsingMethods
     {

--- a/src/ByteSizeLib.Tests/Binary/ParsingMethods.cs
+++ b/src/ByteSizeLib.Tests/Binary/ParsingMethods.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Threading;
-using Xunit;
+﻿using Xunit;
 
 namespace ByteSizeLib.Tests.BinaryByteSizeTests
 {

--- a/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
@@ -32,5 +32,5 @@ namespace ByteSizeLib.Tests.BinaryByteSizeTests
             // Assert
             Assert.Equal($"9{s}77 KiB", result);
         }
-	}
+    }
 }

--- a/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
@@ -7,7 +7,7 @@ namespace ByteSizeLib.Tests.Binary
     {
 
         [Fact]
-        public void ReturnsDefaultRepresenation()
+        public void ReturnsDefaultRepresentation()
         {
             // Arrange
             var b = ByteSize.FromKiloBytes(10);
@@ -20,7 +20,7 @@ namespace ByteSizeLib.Tests.Binary
         }
 
         [Fact]
-        public void ReturnsDefaultRepresenationCurrentCulture()
+        public void ReturnsDefaultRepresentationCurrentCulture()
         {
             // Arrange
             var b = ByteSize.FromKiloBytes(10);

--- a/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Xunit;
 
-namespace ByteSizeLib.Tests.BinaryByteSizeTests
+namespace ByteSizeLib.Tests.Binary
 {
     public class ToBinaryStringMethod
     {

--- a/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
@@ -83,5 +83,5 @@ namespace ByteSizeLib.Tests.BinaryByteSizeTests
             // Assert
             Assert.Equal(10.ToString("0.0 TiB"), result);
         }
-	}
+    }
 }

--- a/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
@@ -1,6 +1,6 @@
 ﻿using Xunit;
 
-namespace ByteSizeLib.Tests.BinaryByteSizeTests
+namespace ByteSizeLib.Tests.Binary
 {
     public class ToStringMethod
     {

--- a/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToStringMethod.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-using System.Threading;
-using Xunit;
+﻿using Xunit;
 
 namespace ByteSizeLib.Tests.BinaryByteSizeTests
 {

--- a/src/ByteSizeLib.Tests/Decimal/ParsingMethods.cs
+++ b/src/ByteSizeLib.Tests/Decimal/ParsingMethods.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Threading;
+﻿using System.Globalization;
 using Xunit;
 
 namespace ByteSizeLib.Tests.Decimal

--- a/src/ByteSizeLib.Tests/Decimal/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Decimal/ToStringMethod.cs
@@ -204,33 +204,33 @@ namespace ByteSizeLib.Tests.Decimal
 
             // Assert
             Assert.Equal("9,8 MB", result);
-		}
-
-		[Fact]
-		public void ReturnsCultureSpecificFormat()
-		{
-			// Arrange
-			var b = ByteSize.FromKiloBytes(10.5);
-
-			// Act
-			var deCulture = new CultureInfo("de-DE");
-			var result = b.ToString("0.0 KB", deCulture);
-
-			// Assert
-			Assert.Equal(10.5.ToString("0.0 KB", deCulture), result);
-		}
+        }
 
         [Fact]
-		public void ReturnsZeroBits()
-		{
-			// Arrange
-			var b = ByteSize.FromBits(0);
+        public void ReturnsCultureSpecificFormat()
+        {
+            // Arrange
+            var b = ByteSize.FromKiloBytes(10.5);
 
-			// Act
-			var result = b.ToString();
+            // Act
+            var deCulture = new CultureInfo("de-DE");
+            var result = b.ToString("0.0 KB", deCulture);
 
-			// Assert
-			Assert.Equal("0 b", result);
-		}
-	}
+            // Assert
+            Assert.Equal(10.5.ToString("0.0 KB", deCulture), result);
+        }
+
+        [Fact]
+        public void ReturnsZeroBits()
+        {
+            // Arrange
+            var b = ByteSize.FromBits(0);
+
+            // Act
+            var result = b.ToString();
+
+            // Assert
+            Assert.Equal("0 b", result);
+        }
+    }
 }

--- a/src/ByteSizeLib.Tests/Decimal/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Decimal/ToStringMethod.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace ByteSizeLib.Tests.Decimal

--- a/src/ByteSizeLib.Tests/ParsingMethods.cs
+++ b/src/ByteSizeLib.Tests/ParsingMethods.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace ByteSizeLib.Tests

--- a/src/ByteSizeLib.Tests/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/ToStringMethod.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Threading;
 using Xunit;
 
 namespace ByteSizeLib.Tests

--- a/src/ByteSizeLib.Tests/ToStringMethod.cs
+++ b/src/ByteSizeLib.Tests/ToStringMethod.cs
@@ -139,33 +139,33 @@ namespace ByteSizeLib.Tests
 
             // Assert
             Assert.Equal("9,8 MB", result);
-		}
-
-		[Fact]
-		public void ReturnsCultureSpecificFormat()
-		{
-			// Arrange
-			var b = ByteSize.FromKiloBytes(10.5);
-
-			// Act
-			var deCulture = new CultureInfo("de-DE");
-			var result = b.ToString("0.0 KB", deCulture);
-
-			// Assert
-			Assert.Equal(10.5.ToString("0.0 KB", deCulture), result);
-		}
+        }
 
         [Fact]
-		public void ReturnsZeroBits()
-		{
-			// Arrange
-			var b = ByteSize.FromBits(0);
+        public void ReturnsCultureSpecificFormat()
+        {
+            // Arrange
+            var b = ByteSize.FromKiloBytes(10.5);
 
-			// Act
-			var result = b.ToString();
+            // Act
+            var deCulture = new CultureInfo("de-DE");
+            var result = b.ToString("0.0 KB", deCulture);
 
-			// Assert
-			Assert.Equal("0 b", result);
-		}
-	}
+            // Assert
+            Assert.Equal(10.5.ToString("0.0 KB", deCulture), result);
+        }
+
+        [Fact]
+        public void ReturnsZeroBits()
+        {
+            // Arrange
+            var b = ByteSize.FromBits(0);
+
+            // Act
+            var result = b.ToString();
+
+            // Assert
+            Assert.Equal("0 b", result);
+        }
+    }
 }

--- a/src/ByteSizeLib/ByteSize.cs
+++ b/src/ByteSizeLib/ByteSize.cs
@@ -14,8 +14,8 @@ namespace ByteSizeLib
         public const long BitsInByte = 8;
         public const string BitSymbol = "b";
         public const string ByteSymbol = "B";
-        public long Bits { get; private set; }
-        public double Bytes { get; private set; }
+        public long Bits { get; }
+        public double Bytes { get; }
 
         public string LargestWholeNumberBinarySymbol
         {

--- a/src/ByteSizeLib/DecimalByteSize.cs
+++ b/src/ByteSizeLib/DecimalByteSize.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Globalization;
-
 namespace ByteSizeLib
 {
     public partial struct ByteSize


### PR DESCRIPTION
* Use 4 spaces instead of tabs everywhere
* Remove all unused imports
* Cleanup ByteSizeLib.Tests.Binary namespace
* Fix typos
* Remove unused private setters