### PR TITLE
Fix ReturnsDefaultRepresenationCurrentCulture test for all cultures

### DIFF
--- a/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
+++ b/src/ByteSizeLib.Tests/Binary/ToBinaryStringMethod.cs
@@ -24,7 +24,7 @@ namespace ByteSizeLib.Tests.BinaryByteSizeTests
         {
             // Arrange
             var b = ByteSize.FromKiloBytes(10);
-            var s = CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator;
+            var s = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
             // Act
             var result = b.ToBinaryString(CultureInfo.CurrentCulture);


### PR DESCRIPTION
Use NumberDecimalSeparator instead of CurrencyDecimalSeparator. In some cultures it may be different. For example, in the fr-CH culture, the currency separator is a dot and the number separator is a comma.