### PR TITLE
Make ByteSize implement the IFormattable interface

### DIFF
--- a/src/ByteSizeLib/ByteSize.cs
+++ b/src/ByteSizeLib/ByteSize.cs
@@ -7,7 +7,7 @@ namespace ByteSizeLib
     /// Represents a byte size value with support for decimal (KiloByte) and
     /// binary values (KibiByte).
     /// </summary>
-    public partial struct ByteSize : IComparable<ByteSize>, IEquatable<ByteSize>
+    public partial struct ByteSize : IComparable<ByteSize>, IEquatable<ByteSize>, IFormattable
     {         
         public static readonly ByteSize MinValue = ByteSize.FromBits(long.MinValue);
         public static readonly ByteSize MaxValue = ByteSize.FromBits(long.MaxValue);
@@ -168,7 +168,12 @@ namespace ByteSizeLib
             return this.ToString(format, CultureInfo.CurrentCulture);
         }
 
-        public string ToString(string format, IFormatProvider provider, bool useBinaryByte = false)
+        public string ToString(string format, IFormatProvider provider)
+        {
+            return this.ToString(format, provider, useBinaryByte: false);
+        }
+
+        public string ToString(string format, IFormatProvider provider, bool useBinaryByte)
         {
             if (!format.Contains("#") && !format.Contains("0"))
                 format = "0.## " + format;


### PR DESCRIPTION
This makes Resharper/Rider happy when using string interpolation, for example: $"{byteSize:0.0}"
Before implementing the IFormattable interface, Resharper would emit this warning:
> Formatting is specified, but interpolated string expression is not IFormattable

Note about compatibility: I'm not 100% sure but I think this change is both source compatible and binary compatible.