### PR TITLE
Support for TypeConverter

### DIFF
--- a/src/ByteSizeLib.Tests/ByteSizeTypeConverterTests.cs
+++ b/src/ByteSizeLib.Tests/ByteSizeTypeConverterTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using System.ComponentModel;
+
+namespace ByteSizeLib.Tests
+{
+    public class ByteSizeTypeConverterTests
+    {
+        [Fact]
+        public void ConvertsToString()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(ByteSize));
+            Assert.NotNull(converter);
+            var bs = ByteSize.FromBytes(1024);
+            var actual =converter.ConvertToString(bs);
+            var expected = "1 KiB";
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(variant2TypesTestData))]
+        public void ConvertsFromString(string input, ByteSize expected)
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(ByteSize));
+            Assert.NotNull(converter);
+            var actualO = converter.ConvertFromString(input);
+            var actual = Assert.IsType<ByteSize>(actualO);
+            Assert.Equal(expected, actual);
+        }
+
+        public static readonly IEnumerable<object[]> variant2TypesTestData = new List<object[]>
+        {
+            new object []{
+                "1 KiB",
+                ByteSize.FromKibiBytes(1),
+            },
+
+            new object []{
+                "1KiB",
+                ByteSize.FromKibiBytes(1),
+            },
+
+            new object []{
+                "1MiB",
+                ByteSize.FromMebiBytes(1),
+            },
+            new object []{
+                "1GiB",
+                ByteSize.FromGibiBytes(1),
+            },
+        };
+
+    }
+}

--- a/src/ByteSizeLib/ByteSize.cs
+++ b/src/ByteSizeLib/ByteSize.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace ByteSizeLib
@@ -7,6 +8,7 @@ namespace ByteSizeLib
     /// Represents a byte size value with support for decimal (KiloByte) and
     /// binary values (KibiByte).
     /// </summary>
+    [TypeConverter(typeof(ByteSizeTypeConverter))]
     public partial struct ByteSize : IComparable<ByteSize>, IEquatable<ByteSize>, IFormattable
     {         
         public static readonly ByteSize MinValue = ByteSize.FromBits(long.MinValue);

--- a/src/ByteSizeLib/ByteSizeLib.csproj
+++ b/src/ByteSizeLib/ByteSizeLib.csproj
@@ -38,6 +38,10 @@ View all release notes at https://github.com/omar/ByteSize/releases.</PackageRel
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+  </ItemGroup>
+
   <!-- Workaround for https://github.com/GitTools/GitVersion/issues/1031 -->
   <PropertyGroup Condition="'$(GitVersion_SemVer)' != ''">
     <GetVersion>false</GetVersion>

--- a/src/ByteSizeLib/ByteSizeTypeConverter.cs
+++ b/src/ByteSizeLib/ByteSizeTypeConverter.cs
@@ -7,7 +7,7 @@ namespace ByteSizeLib
     /// <summary>
     /// Provides a type converter to convert <see cref="ByteSize"/> objects to and from <see cref="string"/> objects.
     /// </summary>
-    public class ByteSizeTypeConverter : TypeConverter
+    internal class ByteSizeTypeConverter : TypeConverter
     {
         /// <inheritdoc/>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => sourceType == typeof(string);

--- a/src/ByteSizeLib/ByteSizeTypeConverter.cs
+++ b/src/ByteSizeLib/ByteSizeTypeConverter.cs
@@ -1,7 +1,8 @@
-﻿using ByteSizeLib;
+﻿using System;
+using System.ComponentModel;
 using System.Globalization;
 
-namespace System.ComponentModel
+namespace ByteSizeLib
 {
     /// <summary>
     /// Provides a type converter to convert <see cref="ByteSize"/> objects to and from <see cref="string"/> objects.

--- a/src/ByteSizeLib/ByteSizeTypeConverter.cs
+++ b/src/ByteSizeLib/ByteSizeTypeConverter.cs
@@ -1,0 +1,31 @@
+﻿using ByteSizeLib;
+using System.Globalization;
+
+namespace System.ComponentModel
+{
+    /// <summary>
+    /// Provides a type converter to convert <see cref="ByteSize"/> objects to and from <see cref="string"/> objects.
+    /// </summary>
+    public class ByteSizeTypeConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => sourceType == typeof(string);
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => destinationType == typeof(string);
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return value is string s ? ByteSize.Parse(s) : base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            return destinationType == typeof(string) && value is ByteSize bs
+                ? bs.ToBinaryString()
+                : base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}


### PR DESCRIPTION
When working with `IConfiguration` in the larger .NET ecosystem, the options pattern is commonly used. Its values can be bound via the `IConfiguration` instances. This binding uses `TypeConverter` underneath. In this PR, `ByteSize` would have that support allowing it to be created from strings via the `TypeConverter` procedures. It is, however, not limited to this usage.

Example:

```cs
public class MyAppOptions {
    public ByteSize MaxDownloadSize { get; set; }
}
```

```cs
public class Startup {
    public Startup (IConfiguration configuration) {
        Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
    }

    public void ConfigureServices(IServiceCollection services) {
        services.Configure<MyAppOptions>(Configuration.GetSection("MyApp"));
    }
}
```

```json
{
    "MyApp": {
        "MaxDownloadSize": "10MiB"
    }
}
```
